### PR TITLE
Move publication off of agol60 and onto PyPI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,8 @@ name: Python (build and publish)
 
 on:
   push:
+    tags:
+      - v*.*.*
 
 jobs:
   build:
@@ -33,6 +35,9 @@ jobs:
       matrix:
         version: ['3.11']
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
 
     steps:
     - uses: actions/checkout@v5
@@ -49,18 +54,5 @@ jobs:
         pip3 install .[build]
         python3 -m build
 
-    - name: Setup Jfrog CLI
-      uses: jfrog/setup-jfrog-cli@v4
-      env:
-        JF_URL: https://artifactory.algol60.net
-        JF_USER: ${{ secrets.ARTIFACTORY_ALGOL60_USERNAME }}
-        JF_ACCESS_TOKEN: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
-
-    - name: Upload to Artifactory
-      run: |
-        PROJECT_NAME=$(basename "${GITHUB_REPOSITORY}")
-        STABLE="${{ github.ref_type == 'tag' && 'simple' || 'unstable' }}"
-        jfrog rt upload --detailed-summary --fail-no-op=true "*.tar.gz" "csm-python-modules/${STABLE}/${PROJECT_NAME}/"
-        jfrog rt upload --detailed-summary --fail-no-op=true "*.whl" "csm-python-modules/${STABLE}/${PROJECT_NAME}/"
-      working-directory:
-        dist/
+    - name: Publish
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary and Scope

Move publication of this vTDS layer from algol60 where it can't be publicly seen to PyPI where it can. I decided to come back to this when I was removing algol60 from the workflows for this project because I was not sure what to do. Now that I know, here are the changes.

